### PR TITLE
Update README with kots install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,17 @@ Currently, setup to demonstrate a minimal production-readly HA/DR platform. So, 
 
 ## Replicated KOTS
 
+Replicated [KOTS](https://kots.io) enables you to manage the app lifecycle of MongoDB Enterprise such as installs, upgrades, rollbacks, troubleshooting, snapshots, etc.
 
+* Install kots as a `kubectl` plugin.
+```shell
+curl https://kots.io/install | bash
+```
+You can rerun the above `curl` command to upgrade `kots`.
+
+* Install MongoDB Total Cluster
+```shell
+kubectl kots install mongodb-enterprise
+```
+
+* TODO: Download the license from the repo.


### PR DESCRIPTION
@jasonmimick I've added minimal instructions on how to install via kots. The only missing bit is the license. We can create a license and perhaps add it to the repo where the Makefile is.

Thanks.

cc: @dexhorthy 