### PR TITLE
Enable bucket value attribution

### DIFF
--- a/addons/tardigade-gateway/templates/config.configmap.yaml
+++ b/addons/tardigade-gateway/templates/config.configmap.yaml
@@ -13,3 +13,4 @@ data:
     minio.access-key: {{ .Values.accessKey }} 
     minio.secret-key: {{ .Values.secretKey }}
     server.address: :7777
+    client.user-agent: MongoDB


### PR DESCRIPTION
Same deal as last time. I am not 100% sure if this config change will enable it. Especially after knowing that the first PR was updating the wrong config. **Please deploy it somewhere at the end and create an empty bucket via aws cli. I will check the bucket in the database to see if it works.**